### PR TITLE
Add search_result list object type

### DIFF
--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -266,6 +266,7 @@ Map<String, dynamic> _$DataListToJson<T>(
 
 const _$_SubListObjectEnumMap = {
   _SubListObject.list: 'list',
+  _SubListObject.searchResult: 'search_result',
 };
 
 EventData<T> _$EventDataFromJson<T>(

--- a/lib/src/messages/data_list.dart
+++ b/lib/src/messages/data_list.dart
@@ -1,6 +1,10 @@
 part of '../../messages.dart';
 
-enum _SubListObject { list }
+enum _SubListObject {
+  list,
+  @JsonValue('search_result')
+  searchResult,
+}
 
 @JsonSerializable()
 class DataList<T> {


### PR DESCRIPTION
Needed for `<resource>/search` endpoints payload parsing to function properly.