### PR TITLE
Add missing fields to Invoice

### DIFF
--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -833,19 +833,26 @@ Map<String, dynamic> _$CouponEventToJson(CouponEvent instance) =>
 
 Invoice _$InvoiceFromJson(Map<String, dynamic> json) => Invoice(
       id: json['id'] as String,
+      amountDue: (json['amount_due'] as num).toInt(),
+      amountOverpaid: (json['amount_overpaid'] as num).toInt(),
+      amountPaid: (json['amount_paid'] as num).toInt(),
+      amountRemaining: (json['amount_remaining'] as num).toInt(),
+      amountShipping: (json['amount_shipping'] as num).toInt(),
       currency: json['currency'] as String,
       customer: json['customer'] as String,
+      startingBalance: (json['starting_balance'] as num).toInt(),
       total: (json['total'] as num).toInt(),
-      totalExcludingTax: (json['total_excluding_tax'] as num).toInt(),
       subtotal: (json['subtotal'] as num).toInt(),
-      subtotalExcludingTax: (json['subtotal_excluding_tax'] as num).toInt(),
       totalDiscountAmounts: (json['total_discount_amounts'] as List<dynamic>)
           .map((e) => TotalDiscountAmount.fromJson(e as Map<String, dynamic>))
           .toList(),
       description: json['description'] as String?,
+      endingBalance: (json['ending_balance'] as num?)?.toInt(),
       hostedInvoiceUrl: json['hosted_invoice_url'] as String?,
       status: json['status'] as String?,
       subscription: json['subscription'] as String?,
+      subtotalExcludingTax: (json['subtotal_excluding_tax'] as num?)?.toInt(),
+      totalExcludingTax: (json['total_excluding_tax'] as num?)?.toInt(),
       paymentIntent: json['payment_intent'] as String?,
       accountCountry: json['account_country'] as String?,
       accountName: json['account_name'] as String?,
@@ -854,10 +861,15 @@ Invoice _$InvoiceFromJson(Map<String, dynamic> json) => Invoice(
 Map<String, dynamic> _$InvoiceToJson(Invoice instance) {
   final val = <String, dynamic>{
     'id': instance.id,
+    'amount_due': instance.amountDue,
+    'amount_overpaid': instance.amountOverpaid,
+    'amount_paid': instance.amountPaid,
+    'amount_remaining': instance.amountRemaining,
+    'amount_shipping': instance.amountShipping,
     'currency': instance.currency,
     'customer': instance.customer,
+    'starting_balance': instance.startingBalance,
     'total': instance.total,
-    'total_excluding_tax': instance.totalExcludingTax,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -866,12 +878,14 @@ Map<String, dynamic> _$InvoiceToJson(Invoice instance) {
     }
   }
 
+  writeNotNull('total_excluding_tax', instance.totalExcludingTax);
   writeNotNull('description', instance.description);
+  writeNotNull('ending_balance', instance.endingBalance);
   writeNotNull('hosted_invoice_url', instance.hostedInvoiceUrl);
   writeNotNull('status', instance.status);
   writeNotNull('subscription', instance.subscription);
   val['subtotal'] = instance.subtotal;
-  val['subtotal_excluding_tax'] = instance.subtotalExcludingTax;
+  writeNotNull('subtotal_excluding_tax', instance.subtotalExcludingTax);
   val['total_discount_amounts'] =
       instance.totalDiscountAmounts.map((e) => e.toJson()).toList();
   writeNotNull('payment_intent', instance.paymentIntent);

--- a/lib/src/messages/invoice.dart
+++ b/lib/src/messages/invoice.dart
@@ -7,6 +7,16 @@ class Invoice extends Message {
   /// the invoice is an upcoming invoice.
   final String id;
 
+  final int amountDue;
+
+  final int amountOverpaid;
+
+  final int amountPaid;
+
+  final int amountRemaining;
+
+  final int amountShipping;
+
   /// Three-letter ISO currency code, in lowercase. Must be a supported
   /// currency.
   final String currency;
@@ -14,16 +24,20 @@ class Invoice extends Message {
   /// The ID of the customer who will be billed.
   final String customer;
 
+  final int startingBalance;
+
   /// Total after discounts and taxes.
   final int total;
 
   /// The integer amount in cents representing the total amount of the invoice
   /// including all discounts but excluding all tax.
-  final int totalExcludingTax;
+  final int? totalExcludingTax;
 
   /// An arbitrary string attached to the object. Often useful for displaying
   /// to users. Referenced as ‘memo’ in the Dashboard.
   final String? description;
+
+  final int? endingBalance;
 
   /// The URL for the hosted invoice page, which allows customers to view and
   /// pay an invoice. If the invoice has not been finalized yet, this will be
@@ -45,7 +59,7 @@ class Invoice extends Message {
   /// The integer amount in cents representing the subtotal of the invoice
   /// before any invoice level discount or tax is applied. Item discounts are
   /// already incorporated
-  final int subtotalExcludingTax;
+  final int? subtotalExcludingTax;
 
   /// The aggregate amounts calculated per discount across all line items.
   final List<TotalDiscountAmount> totalDiscountAmounts;
@@ -65,17 +79,24 @@ class Invoice extends Message {
 
   Invoice({
     required this.id,
+    required this.amountDue,
+    required this.amountOverpaid,
+    required this.amountPaid,
+    required this.amountRemaining,
+    required this.amountShipping,
     required this.currency,
     required this.customer,
+    required this.startingBalance,
     required this.total,
-    required this.totalExcludingTax,
     required this.subtotal,
-    required this.subtotalExcludingTax,
     required this.totalDiscountAmounts,
     this.description,
+    this.endingBalance,
     this.hostedInvoiceUrl,
     this.status,
     this.subscription,
+    this.subtotalExcludingTax,
+    this.totalExcludingTax,
     this.paymentIntent,
     this.accountCountry,
     this.accountName,

--- a/lib/src/messages/invoice.dart
+++ b/lib/src/messages/invoice.dart
@@ -7,14 +7,26 @@ class Invoice extends Message {
   /// the invoice is an upcoming invoice.
   final String id;
 
+  /// Final amount due at this time for this invoice. If the invoice’s total is
+  /// smaller than the minimum charge amount, for example, or if there is
+  /// account credit that can be applied to the invoice, the amount_due may
+  /// be 0. If there is a positive starting_balance for the invoice (the
+  /// customer owes money), the amount_due will also take that into account.
+  /// The charge that gets generated for the invoice will be for the amount
+  /// specified in amount_due.
   final int amountDue;
 
+  /// Amount that was overpaid on the invoice. The amount overpaid is credited
+  /// to the customer’s credit balance.
   final int amountOverpaid;
 
+  /// The amount, in cents, that was paid.
   final int amountPaid;
 
+  /// The difference between amount_due and amount_paid, in cents.
   final int amountRemaining;
 
+  /// This is the sum of all the shipping amounts.
   final int amountShipping;
 
   /// Three-letter ISO currency code, in lowercase. Must be a supported
@@ -24,6 +36,10 @@ class Invoice extends Message {
   /// The ID of the customer who will be billed.
   final String customer;
 
+  /// Starting customer balance before the invoice is finalized. If the invoice
+  /// has not been finalized yet, this will be the current customer balance.
+  /// For revision invoices, this also includes any customer balance that was
+  /// applied to the original invoice.
   final int startingBalance;
 
   /// Total after discounts and taxes.
@@ -37,6 +53,10 @@ class Invoice extends Message {
   /// to users. Referenced as ‘memo’ in the Dashboard.
   final String? description;
 
+  /// Ending customer balance after the invoice is finalized. Invoices are
+  /// finalized approximately an hour after successful webhook delivery or when
+  /// payment collection is attempted for the invoice. If the invoice has not
+  /// been finalized yet, this will be null.
   final int? endingBalance;
 
   /// The URL for the hosted invoice page, which allows customers to view and


### PR DESCRIPTION
## Description

- Added some missing fields to the Invoice model.
- Made `totalExcludingTax` and `subtotalExcludingTax` fields on Invoice nullable according to the API docs.