### PR TITLE
Add TimestampConverter to prorationDate and trialEnd fields

### DIFF
--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -1760,9 +1760,8 @@ CreatePreviewInvoiceSubscriptionDetailsRequest
               .toList(),
           prorationBehavior: $enumDecodeNullable(
               _$ProrationBehaviorEnumMap, json['proration_behavior']),
-          prorationDate: json['proration_date'] == null
-              ? null
-              : DateTime.parse(json['proration_date'] as String),
+          prorationDate: _$JsonConverterFromJson<int, DateTime>(
+              json['proration_date'], const TimestampConverter().fromJson),
           startDate: _$JsonConverterFromJson<int, DateTime>(
               json['start_date'], const TimestampConverter().fromJson),
           trialEnd: json['trial_end'] == null
@@ -1794,7 +1793,10 @@ Map<String, dynamic> _$CreatePreviewInvoiceSubscriptionDetailsRequestToJson(
   writeNotNull('items', instance.items?.map((e) => e.toJson()).toList());
   writeNotNull('proration_behavior',
       _$ProrationBehaviorEnumMap[instance.prorationBehavior]);
-  writeNotNull('proration_date', instance.prorationDate?.toIso8601String());
+  writeNotNull(
+      'proration_date',
+      _$JsonConverterToJson<int, DateTime>(
+          instance.prorationDate, const TimestampConverter().toJson));
   writeNotNull(
       'start_date',
       _$JsonConverterToJson<int, DateTime>(

--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -1764,9 +1764,8 @@ CreatePreviewInvoiceSubscriptionDetailsRequest
               json['proration_date'], const TimestampConverter().fromJson),
           startDate: _$JsonConverterFromJson<int, DateTime>(
               json['start_date'], const TimestampConverter().fromJson),
-          trialEnd: json['trial_end'] == null
-              ? null
-              : DateTime.parse(json['trial_end'] as String),
+          trialEnd: _$JsonConverterFromJson<int, DateTime>(
+              json['trial_end'], const TimestampConverter().fromJson),
         );
 
 Map<String, dynamic> _$CreatePreviewInvoiceSubscriptionDetailsRequestToJson(
@@ -1801,7 +1800,10 @@ Map<String, dynamic> _$CreatePreviewInvoiceSubscriptionDetailsRequestToJson(
       'start_date',
       _$JsonConverterToJson<int, DateTime>(
           instance.startDate, const TimestampConverter().toJson));
-  writeNotNull('trial_end', instance.trialEnd?.toIso8601String());
+  writeNotNull(
+      'trial_end',
+      _$JsonConverterToJson<int, DateTime>(
+          instance.trialEnd, const TimestampConverter().toJson));
   return val;
 }
 

--- a/lib/src/messages/requests/create_invoice_preview_request.dart
+++ b/lib/src/messages/requests/create_invoice_preview_request.dart
@@ -101,6 +101,7 @@ class CreatePreviewInvoiceSubscriptionDetailsRequest {
   /// If provided, the invoice returned will preview updating or creating a
   /// subscription with that trial end. If set, one of
   /// subscription_details.items or subscription is required.
+  @TimestampConverter()
   final DateTime? trialEnd;
 
   CreatePreviewInvoiceSubscriptionDetailsRequest({

--- a/lib/src/messages/requests/create_invoice_preview_request.dart
+++ b/lib/src/messages/requests/create_invoice_preview_request.dart
@@ -91,6 +91,7 @@ class CreatePreviewInvoiceSubscriptionDetailsRequest {
   /// subscription, and one of subscription_details.items, or
   /// subscription_details.trial_end are required. Also,
   /// subscription_details.proration_behavior cannot be set to ‘none’.
+  @TimestampConverter()
   final DateTime? prorationDate;
 
   /// Date a subscription is intended to start (can be future or past).


### PR DESCRIPTION
## Description

- Added `TimestampConverter` annotation to `prorationDate` and `trialEnd` fields of `CreateInvoicePreviewRequest`. Previously, non-null values in these fields caused an error because Stripe could not parse the incorrect date format.